### PR TITLE
Refactor event list to new type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,9 @@
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/ban-ts-comment": ["error", {
+        "ts-ignore": "allow-with-description"
+    }],
     "import/extensions": "off",
     "import/no-unresolved": "off",
     "import/prefer-default-export": "off",

--- a/src/events.ts
+++ b/src/events.ts
@@ -124,12 +124,13 @@ export const EVENTS: EventMap = {
     'ColonyInitialised(address,address,address)': {
       signature: 'ColonyInitialised(address,address,address)',
     },
-     // eslint-disable-next-line max-len
-    'ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)': {
-      signature:
-        // eslint-disable-next-line max-len
-        'ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)',
-    },
+    // eslint-disable-next-line max-len
+    'ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)':
+      {
+        signature:
+          // eslint-disable-next-line max-len
+          'ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)',
+      },
     'ColonyFundsClaimed(address,address,uint256,uint256)': {
       signature: 'ColonyFundsClaimed(address,address,uint256,uint256)',
     },
@@ -203,7 +204,8 @@ export const EVENTS: EventMap = {
       signature: 'ExpenditureSkillSet(address,uint256,uint256,uint256)',
     },
     'ExpenditurePayoutSet(address,uint256,uint256,address,uint256)': {
-      signature: 'ExpenditurePayoutSet(address,uint256,uint256,address,uint256)',
+      signature:
+        'ExpenditurePayoutSet(address,uint256,uint256,address,uint256)',
     },
     'Annotation(address,bytes32,string)': {
       signature: 'Annotation(address,bytes32,string)',
@@ -310,15 +312,12 @@ export const EVENTS: EventMap = {
     },
     'MetaTransactionExecuted(address,address,bytes)': {
       signature: 'MetaTransactionExecuted(address,address,bytes)',
-    },  
+    },
   },
   OneTxPayment: {
     'OneTxPaymentMade(address,uint256,uint256)': {
       signature: 'OneTxPaymentMade(address,uint256,uint256)',
       // connectedEvents: [''],
-    },
-    'OneTxPaymentMade': {
-      signature: 'OneTxPaymentMade',
     },
   },
   VotingReputation: {
@@ -357,6 +356,6 @@ export const EVENTS: EventMap = {
     },
     'MetaTransactionExecuted(address,address,bytes)': {
       signature: 'MetaTransactionExecuted(address,address,bytes)',
-    },  
+    },
   },
 };

--- a/src/events.ts
+++ b/src/events.ts
@@ -12,352 +12,351 @@ type EventMap = {
   };
 };
 
-// FIXME: event signature needs to be the key. Maybe it will be easier to type then
+// event signature needs to be the key. Maybe it will be easier to type then
 export const EVENTS: EventMap = {
   ColonyNetwork: {
     // Common network events
-    ColonyNetworkInitialised: {
+    'ColonyNetworkInitialised(address)': {
       signature: 'ColonyNetworkInitialised(address)',
     },
-    ColonyAdded: {
+    'ColonyAdded(uint256,address,address)': {
       signature: 'ColonyAdded(uint256,address,address)',
     },
-    SkillAdded: {
+    'SkillAdded(uint256,uint256)': {
       signature: 'SkillAdded(uint256,uint256)',
     },
-    TokenAuthorityDeployed: {
+    'TokenAuthorityDeployed(address)': {
       signature: 'TokenAuthorityDeployed(address)',
     },
-    TokenDeployed: {
+    'TokenDeployed(address)': {
       signature: 'TokenDeployed(address)',
     },
     // Less common network events
-    TokenLockingAddressSet: {
+    'TokenLockingAddressSet(address)': {
       signature: 'TokenLockingAddressSet(address)',
     },
-    MiningCycleResolverSet: {
+    'MiningCycleResolverSet(address)': {
       signature: 'MiningCycleResolverSet(address)',
     },
-    NetworkFeeInverseSet: {
+    'NetworkFeeInverseSet(uint256)': {
       signature: 'NetworkFeeInverseSet(uint256)',
     },
-    ColonyVersionAdded: {
+    'ColonyVersionAdded(uint256,address)': {
       signature: 'ColonyVersionAdded(uint256,address)',
     },
-    MetaColonyCreated: {
+    'MetaColonyCreated(address,address,uint256)': {
       signature: 'MetaColonyCreated(address,address,uint256)',
     },
-    AuctionCreated: {
+    'AuctionCreated(address,address,uint256)': {
       signature: 'AuctionCreated(address,address,uint256)',
     },
-    ReputationMiningInitialised: {
+    'ReputationMiningInitialised(address)': {
       signature: 'ReputationMiningInitialised(address)',
     },
-    ReputationMiningCycleComplete: {
+    'ReputationMiningCycleComplete(bytes32,uint256)': {
       signature: 'ReputationMiningCycleComplete(bytes32,uint256)',
     },
-    ReputationRootHashSet: {
+    'ReputationRootHashSet(bytes32,uint256,address[],uint256)': {
       signature: 'ReputationRootHashSet(bytes32,uint256,address[],uint256)',
     },
-    UserLabelRegistered: {
+    'UserLabelRegistered(address,bytes32)': {
       signature: 'UserLabelRegistered(address,bytes32)',
     },
-    ColonyLabelRegistered: {
+    'ColonyLabelRegistered(address,bytes32)': {
       signature: 'ColonyLabelRegistered(address,bytes32)',
     },
-    RecoveryRoleSet: {
+    'RecoveryRoleSet(address,bool)': {
       signature: 'RecoveryRoleSet(address,bool)',
     },
-    ExtensionAddedToNetwork: {
+    'ExtensionAddedToNetwork(bytes32,uint256)': {
       signature: 'ExtensionAddedToNetwork(bytes32,uint256)',
     },
-    ExtensionDeprecated: {
+    'ExtensionDeprecated(bytes32,address,bool)': {
       signature: 'ExtensionDeprecated(bytes32,address,bool)',
     },
-    ExtensionInstalled: {
+    'ExtensionInstalled(bytes32,address,uint256)': {
       signature: 'ExtensionInstalled(bytes32,address,uint256)',
     },
-    ExtensionUninstalled: {
+    'ExtensionUninstalled(bytes32,address)': {
       signature: 'ExtensionUninstalled(bytes32,address)',
     },
-    ExtensionUpgraded: {
+    'ExtensionUpgraded(bytes32,address,uint256)': {
       signature: 'ExtensionUpgraded(bytes32,address,uint256)',
     },
-    RecoveryModeEntered: {
+    'RecoveryModeEntered(address)': {
       signature: 'RecoveryModeEntered(address)',
     },
-    RecoveryModeExitApproved: {
+    'RecoveryModeExitApproved(address)': {
       signature: 'RecoveryModeExitApproved(address)',
     },
-    RecoveryModeExited: {
+    'RecoveryModeExited(address)': {
       signature: 'RecoveryModeExited(address)',
     },
-    RecoveryStorageSlotSet: {
+    'RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)': {
       signature: 'RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)',
     },
-    RegistrarInitialised: {
+    'RegistrarInitialised(address,bytes32)': {
       signature: 'RegistrarInitialised(address,bytes32)',
     },
-    ReputationMinerPenalised: {
+    'ReputationMinerPenalised(address,uint256)': {
       signature: 'ReputationMinerPenalised(address,uint256)',
     },
-    ReputationMiningRewardSet: {
+    'ReputationMiningRewardSet(uint256)': {
       signature: 'ReputationMiningRewardSet(uint256)',
     },
-    TokenWhitelisted: {
+    'TokenWhitelisted(address,bool)': {
       signature: 'TokenWhitelisted(address,bool)',
     },
-    MetaTransactionExecuted: {
+    'MetaTransactionExecuted(address,address,bytes)': {
       signature: 'MetaTransactionExecuted(address,address,bytes)',
     },
   },
   Colony: {
     // Common Colony events
-    DomainAdded: {
+    'DomainAdded(address,uint256)': {
       signature: 'DomainAdded(address,uint256)',
       connectedEvents: ['DomainMetadata', 'Annotation'],
     },
-    DomainMetadata: {
+    'DomainMetadata(address,uint256,string)': {
       signature: 'DomainMetadata(address,uint256,string)',
       auxiliaryEvent: true,
     },
-    ColonyInitialised: {
+    'ColonyInitialised(address,address,address)': {
       signature: 'ColonyInitialised(address,address,address)',
     },
-    ColonyFundsMovedBetweenFundingPots: {
+     // eslint-disable-next-line max-len
+    'ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)': {
       signature:
         // eslint-disable-next-line max-len
         'ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)',
     },
-    ColonyFundsClaimed: {
+    'ColonyFundsClaimed(address,address,uint256,uint256)': {
       signature: 'ColonyFundsClaimed(address,address,uint256,uint256)',
     },
-    RewardPayoutCycleStarted: {
+    'RewardPayoutCycleStarted(address,uint256)': {
       signature: 'RewardPayoutCycleStarted(address,uint256)',
     },
-    RewardPayoutCycleEnded: {
+    'RewardPayoutCycleEnded(address,uint256)': {
       signature: 'RewardPayoutCycleEnded(address,uint256)',
     },
-    RewardPayoutClaimed: {
+    'RewardPayoutClaimed(uint256,address,uint256,uint256)': {
       signature: 'RewardPayoutClaimed(uint256,address,uint256,uint256)',
     },
-    PaymentAdded: {
+    'PaymentAdded(address,uint256)': {
       signature: 'PaymentAdded(address,uint256)',
     },
-    TaskAdded: {
+    'TaskAdded(address,uint256)': {
       signature: 'TaskAdded(address,uint256)',
     },
-    TaskBriefSet: {
+    'TaskBriefSet(uint256,bytes32)': {
       signature: 'TaskBriefSet(uint256,bytes32)',
     },
-    TaskDueDateSet: {
+    'TaskDueDateSet(uint256,uint256)': {
       signature: 'TaskDueDateSet(uint256,uint256)',
     },
-    TaskDomainSet: {
+    'TaskDomainSet(uint256,uint256)': {
       signature: 'TaskDomainSet(uint256,uint256)',
     },
-    TaskSkillSet: {
+    'TaskSkillSet(uint256,uint256)': {
       signature: 'TaskSkillSet(uint256,uint256)',
     },
-    TaskRoleUserSet: {
+    'TaskRoleUserSet(uint256,uint8,address)': {
       signature: 'TaskRoleUserSet(uint256,uint8,address)',
     },
-    TaskPayoutSet: {
+    'TaskPayoutSet(uint256,uint8,address,uint256)': {
       signature: 'TaskPayoutSet(uint256,uint8,address,uint256)',
     },
-    TaskDeliverableSubmitted: {
+    'TaskDeliverableSubmitted(address,uint256,bytes32)': {
       signature: 'TaskDeliverableSubmitted(address,uint256,bytes32)',
     },
-    TaskCompleted: {
+    'TaskCompleted(address,uint256)': {
       signature: 'TaskCompleted(address,uint256)',
     },
-    TaskWorkRatingRevealed: {
+    'TaskWorkRatingRevealed(address,uint256,uint8,uint8)': {
       signature: 'TaskWorkRatingRevealed(address,uint256,uint8,uint8)',
     },
-    TaskFinalized: {
+    'TaskFinalized(address,uint256)': {
       signature: 'TaskFinalized(address,uint256)',
     },
-    PayoutClaimed: {
+    'PayoutClaimed(address,uint256,address,uint256)': {
       signature: 'PayoutClaimed(address,uint256,address,uint256)',
     },
-    TaskCanceled: {
+    'TaskCanceled(uint256)': {
       signature: 'TaskCanceled(uint256)',
     },
-    ExpenditureAdded: {
+    'ExpenditureAdded(address,uint256)': {
       signature: 'ExpenditureAdded(address,uint256)',
     },
-    ExpenditureTransferred: {
+    'ExpenditureTransferred(address,uint256,address)': {
       signature: 'ExpenditureTransferred(address,uint256,address)',
     },
-    ExpenditureCancelled: {
+    'ExpenditureCancelled(address,uint256)': {
       signature: 'ExpenditureCancelled(address,uint256)',
     },
-    ExpenditureFinalized: {
+    'ExpenditureFinalized(address,uint256)': {
       signature: 'ExpenditureFinalized(address,uint256)',
     },
-    ExpenditureRecipientSet: {
+    'ExpenditureRecipientSet(address,uint256,uint256,address)': {
       signature: 'ExpenditureRecipientSet(address,uint256,uint256,address)',
     },
-    ExpenditureSkillSet: {
+    'ExpenditureSkillSet(address,uint256,uint256,uint256)': {
       signature: 'ExpenditureSkillSet(address,uint256,uint256,uint256)',
     },
-    ExpenditurePayoutSet: {
-      signature:
-        'ExpenditurePayoutSet(address,uint256,uint256,address,uint256)',
+    'ExpenditurePayoutSet(address,uint256,uint256,address,uint256)': {
+      signature: 'ExpenditurePayoutSet(address,uint256,uint256,address,uint256)',
     },
-    Annotation: {
+    'Annotation(address,bytes32,string)': {
       signature: 'Annotation(address,bytes32,string)',
-      auxiliaryEvent: true,
     },
-    PaymentFinalized: {
+    'PaymentFinalized(address,uint256)': {
       signature: 'PaymentFinalized(address,uint256)',
     },
-    PaymentPayoutSet: {
+    'PaymentPayoutSet(address,uint256,address,uint256)': {
       signature: 'PaymentPayoutSet(address,uint256,address,uint256)',
     },
-    PaymentRecipientSet: {
+    'PaymentRecipientSet(address,uint256,address)': {
       signature: 'PaymentRecipientSet(address,uint256,address)',
     },
-    PaymentSkillSet: {
+    'PaymentSkillSet(address,uint256,uint256)': {
       signature: 'PaymentSkillSet(address,uint256,uint256)',
     },
-    ColonyFundingRoleSet: {
+    'ColonyFundingRoleSet(address,bool)': {
       signature: 'ColonyFundingRoleSet(address,bool)',
     },
-    ColonyAdministrationRoleSet: {
+    'ColonyAdministrationRoleSet(address,bool)': {
       signature: 'ColonyAdministrationRoleSet(address,bool)',
     },
-    ColonyArchitectureRoleSet: {
+    'ColonyArchitectureRoleSet(address,bool)': {
       signature: 'ColonyArchitectureRoleSet(address,bool)',
     },
-    ColonyRootRoleSet: {
+    'ColonyRootRoleSet(address,bool)': {
       signature: 'ColonyRootRoleSet(address,bool)',
     },
     // Less common Colony events
-    ColonyBootstrapped: {
+    'ColonyBootstrapped(address,address[],int256[])': {
       signature: 'ColonyBootstrapped(address,address[],int256[])',
     },
-    ColonyUpgraded: {
+    'ColonyUpgraded(address,uint256,uint256)': {
       signature: 'ColonyUpgraded(address,uint256,uint256)',
     },
-    ColonyRoleSet: {
+    'ColonyRoleSet(address,address,uint256,uint8,bool)': {
       signature: 'ColonyRoleSet(address,address,uint256,uint8,bool)',
     },
-    ColonyRewardInverseSet: {
+    'ColonyRewardInverseSet(address,uint256)': {
       signature: 'ColonyRewardInverseSet(address,uint256)',
     },
-    FundingPotAdded: {
+    'FundingPotAdded(uint256)': {
       signature: 'FundingPotAdded(uint256)',
     },
-    RecoveryRoleSet: {
+    'RecoveryRoleSet(address,bool)': {
       signature: 'RecoveryRoleSet(address,bool)',
     },
-    ColonyMetadata: {
+    'ColonyMetadata(address,string)': {
       signature: 'ColonyMetadata(address,string)',
     },
-    RecoveryModeEntered: {
+    'RecoveryModeEntered(address)': {
       signature: 'RecoveryModeEntered(address)',
     },
-    RecoveryModeExitApproved: {
+    'RecoveryModeExitApproved(address)': {
       signature: 'RecoveryModeExitApproved(address)',
     },
-    RecoveryModeExited: {
+    'RecoveryModeExited(address)': {
       signature: 'RecoveryModeExited(address)',
     },
-    RecoveryStorageSlotSet: {
+    'RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)': {
       signature: 'RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)',
     },
-    TaskChangedViaSignatures: {
+    'TaskChangedViaSignatures(address[])': {
       signature: 'TaskChangedViaSignatures(address[])',
     },
-    TokenUnlocked: {
+    'TokenUnlocked(address)': {
       signature: 'TokenUnlocked(address)',
     },
-    TokensBurned: {
+    'TokensBurned(address,address,uint256)': {
       signature: 'TokensBurned(address,address,uint256)',
     },
-    TokensMinted: {
+    'TokensMinted(address,address,uint256)': {
       signature: 'TokensMinted(address,address,uint256)',
     },
-    ArbitraryReputationUpdate: {
+    'ArbitraryReputationUpdate(address,address,uint256,int256)': {
       signature: 'ArbitraryReputationUpdate(address,address,uint256,int256)',
     },
-    ExpenditureClaimDelaySet: {
+    'ExpenditureClaimDelaySet(address,uint256,uint256,uint256)': {
       signature: 'ExpenditureClaimDelaySet(address,uint256,uint256,uint256)',
     },
-    ExpenditureGlobalClaimDelaySet: {
+    'ExpenditureGlobalClaimDelaySet(address,uint256)': {
       signature: 'ExpenditureGlobalClaimDelaySet(address,uint256)',
     },
-    ExpenditureLocked: {
+    'ExpenditureLocked(address,uint256)': {
       signature: 'ExpenditureLocked(address,uint256)',
     },
-    ExpenditureMetadataSet: {
+    'ExpenditureMetadataSet(address,uint256,string)': {
       signature: 'ExpenditureMetadataSet(address,uint256,string)',
     },
-    ExpenditurePayoutModifierSet: {
+    'ExpenditurePayoutModifierSet(address,uint256,uint256,int256)': {
       signature: 'ExpenditurePayoutModifierSet(address,uint256,uint256,int256)',
     },
-    ColonyMetadataDelta: {
+    'ColonyMetadataDelta(address,string)': {
       signature: 'ColonyMetadataDelta(address,string)',
     },
-    DomainDeprecated: {
+    'DomainDeprecated(address,uint256,bool)': {
       signature: 'DomainDeprecated(address,uint256,bool)',
     },
-    LocalSkillAdded: {
+    'LocalSkillAdded(address,uint256)': {
       signature: 'LocalSkillAdded(address,uint256)',
     },
-    LocalSkillDeprecated: {
+    'LocalSkillDeprecated(address,uint256,bool)': {
       signature: 'LocalSkillDeprecated(address,uint256,bool)',
     },
-    MetaTransactionExecuted: {
+    'MetaTransactionExecuted(address,address,bytes)': {
       signature: 'MetaTransactionExecuted(address,address,bytes)',
-    },
+    },  
   },
   OneTxPayment: {
     'OneTxPaymentMade(address,uint256,uint256)': {
       signature: 'OneTxPaymentMade(address,uint256,uint256)',
       // connectedEvents: [''],
     },
-    OneTxPaymentMade: {
+    'OneTxPaymentMade': {
       signature: 'OneTxPaymentMade',
     },
   },
   VotingReputation: {
-    ExtensionInitialised: {
+    'ExtensionInitialised()': {
       signature: 'ExtensionInitialised()',
     },
-    LogSetAuthority: {
+    'LogSetAuthority(address)': {
       signature: 'LogSetAuthority(address)',
     },
-    LogSetOwner: {
+    'LogSetOwner(address)': {
       signature: 'LogSetOwner(address)',
     },
-    MotionCreated: {
+    'MotionCreated(uint256,address,uint256)': {
       signature: 'MotionCreated(uint256,address,uint256)',
     },
-    MotionEscalated: {
+    'MotionEscalated(uint256,address,uint256,uint256)': {
       signature: 'MotionEscalated(uint256,address,uint256,uint256)',
     },
-    MotionEventSet: {
+    'MotionEventSet(uint256,uint256)': {
       signature: 'MotionEventSet(uint256,uint256)',
     },
-    MotionFinalized: {
+    'MotionFinalized(uint256,bytes,bool)': {
       signature: 'MotionFinalized(uint256,bytes,bool)',
     },
-    MotionRewardClaimed: {
+    'MotionRewardClaimed(uint256,address,uint256,uint256)': {
       signature: 'MotionRewardClaimed(uint256,address,uint256,uint256)',
     },
-    MotionStaked: {
+    'MotionStaked(uint256,address,uint256,uint256)': {
       signature: 'MotionStaked(uint256,address,uint256,uint256)',
     },
-    MotionVoteRevealed: {
+    'MotionVoteRevealed(uint256,address,uint256)': {
       signature: 'MotionVoteRevealed(uint256,address,uint256)',
     },
-    MotionVoteSubmitted: {
+    'MotionVoteSubmitted(uint256,address)': {
       signature: 'MotionVoteSubmitted(uint256,address)',
     },
-    MetaTransactionExecuted: {
+    'MetaTransactionExecuted(address,address,bytes)': {
       signature: 'MetaTransactionExecuted(address,address,bytes)',
-    },
+    },  
   },
 };

--- a/src/events.ts
+++ b/src/events.ts
@@ -2,352 +2,362 @@ import { EventSources, EventSource } from '@colony/sdk';
 
 interface EventDescription<T extends EventSource> {
   signature: keyof T['filters'];
+  auxiliaryEvent?: true;
+  connectedEvents?: Array<keyof T['filters']>;
 }
 
-const createEventMap = <T, D extends keyof EventSources>(
-  _eventSource: D,
-  map: { [K in keyof T]: EventDescription<EventSources[D]> },
-) => map;
+type EventMap = {
+  [S in keyof EventSources]: {
+    [K in keyof EventSources[S]['filters']]?: EventDescription<EventSources[S]>;
+  };
+};
 
-export const ColonyNetworkEvents = createEventMap('ColonyNetwork', {
-  // Common network events
-  ColonyNetworkInitialised: {
-    signature: 'ColonyNetworkInitialised(address)',
-  },
-  ColonyAdded: {
-    signature: 'ColonyAdded(uint256,address,address)',
-  },
-  SkillAdded: {
-    signature: 'SkillAdded(uint256,uint256)',
-  },
-  TokenAuthorityDeployed: {
-    signature: 'TokenAuthorityDeployed(address)',
-  },
-  TokenDeployed: {
-    signature: 'TokenDeployed(address)',
-  },
-  // Less common network events
-  TokenLockingAddressSet: {
-    signature: 'TokenLockingAddressSet(address)',
-  },
-  MiningCycleResolverSet: {
-    signature: 'MiningCycleResolverSet(address)',
-  },
-  NetworkFeeInverseSet: {
-    signature: 'NetworkFeeInverseSet(uint256)',
-  },
-  ColonyVersionAdded: {
-    signature: 'ColonyVersionAdded(uint256,address)',
-  },
-  MetaColonyCreated: {
-    signature: 'MetaColonyCreated(address,address,uint256)',
-  },
-  AuctionCreated: {
-    signature: 'AuctionCreated(address,address,uint256)',
-  },
-  ReputationMiningInitialised: {
-    signature: 'ReputationMiningInitialised(address)',
-  },
-  ReputationMiningCycleComplete: {
-    signature: 'ReputationMiningCycleComplete(bytes32,uint256)',
-  },
-  ReputationRootHashSet: {
-    signature: 'ReputationRootHashSet(bytes32,uint256,address[],uint256)',
-  },
-  UserLabelRegistered: {
-    signature: 'UserLabelRegistered(address,bytes32)',
-  },
-  ColonyLabelRegistered: {
-    signature: 'ColonyLabelRegistered(address,bytes32)',
-  },
-  RecoveryRoleSet: {
-    signature: 'RecoveryRoleSet(address,bool)',
-  },
-  ExtensionAddedToNetwork: {
-    signature: 'ExtensionAddedToNetwork(bytes32,uint256)',
-  },
-  ExtensionDeprecated: {
-    signature: 'ExtensionDeprecated(bytes32,address,bool)',
-  },
-  ExtensionInstalled: {
-    signature: 'ExtensionInstalled(bytes32,address,uint256)',
-  },
-  ExtensionUninstalled: {
-    signature: 'ExtensionUninstalled(bytes32,address)',
-  },
-  ExtensionUpgraded: {
-    signature: 'ExtensionUpgraded(bytes32,address,uint256)',
-  },
-  RecoveryModeEntered: {
-    signature: 'RecoveryModeEntered(address)',
-  },
-  RecoveryModeExitApproved: {
-    signature: 'RecoveryModeExitApproved(address)',
-  },
-  RecoveryModeExited: {
-    signature: 'RecoveryModeExited(address)',
-  },
-  RecoveryStorageSlotSet: {
-    signature: 'RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)',
-  },
-  RegistrarInitialised: {
-    signature: 'RegistrarInitialised(address,bytes32)',
-  },
-  ReputationMinerPenalised: {
-    signature: 'ReputationMinerPenalised(address,uint256)',
-  },
-  ReputationMiningRewardSet: {
-    signature: 'ReputationMiningRewardSet(uint256)',
-  },
-  TokenWhitelisted: {
-    signature: 'TokenWhitelisted(address,bool)',
-  },
-  MetaTransactionExecuted: {
-    signature: 'MetaTransactionExecuted(address,address,bytes)',
-  },
-});
-
-/* eslint-disable max-len */
-export const ColonyEvents = createEventMap('Colony', {
-  // Common Colony events
-  DomainAdded: {
-    signature: 'DomainAdded(address,uint256)',
-  },
-  DomainMetadata: {
-    signature: 'DomainMetadata(address,uint256,string)',
-  },
-  ColonyInitialised: {
-    signature: 'ColonyInitialised(address,address,address)',
-  },
-  ColonyFundsMovedBetweenFundingPots: {
-    signature:
-      'ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)',
-  },
-  ColonyFundsClaimed: {
-    signature: 'ColonyFundsClaimed(address,address,uint256,uint256)',
-  },
-  RewardPayoutCycleStarted: {
-    signature: 'RewardPayoutCycleStarted(address,uint256)',
-  },
-  RewardPayoutCycleEnded: {
-    signature: 'RewardPayoutCycleEnded(address,uint256)',
-  },
-  RewardPayoutClaimed: {
-    signature: 'RewardPayoutClaimed(uint256,address,uint256,uint256)',
-  },
-  PaymentAdded: {
-    signature: 'PaymentAdded(address,uint256)',
-  },
-  TaskAdded: {
-    signature: 'TaskAdded(address,uint256)',
-  },
-  TaskBriefSet: {
-    signature: 'TaskBriefSet(uint256,bytes32)',
-  },
-  TaskDueDateSet: {
-    signature: 'TaskDueDateSet(uint256,uint256)',
-  },
-  TaskDomainSet: {
-    signature: 'TaskDomainSet(uint256,uint256)',
-  },
-  TaskSkillSet: {
-    signature: 'TaskSkillSet(uint256,uint256)',
-  },
-  TaskRoleUserSet: {
-    signature: 'TaskRoleUserSet(uint256,uint8,address)',
-  },
-  TaskPayoutSet: {
-    signature: 'TaskPayoutSet(uint256,uint8,address,uint256)',
-  },
-  TaskDeliverableSubmitted: {
-    signature: 'TaskDeliverableSubmitted(address,uint256,bytes32)',
-  },
-  TaskCompleted: {
-    signature: 'TaskCompleted(address,uint256)',
-  },
-  TaskWorkRatingRevealed: {
-    signature: 'TaskWorkRatingRevealed(address,uint256,uint8,uint8)',
-  },
-  TaskFinalized: {
-    signature: 'TaskFinalized(address,uint256)',
-  },
-  PayoutClaimed: {
-    signature: 'PayoutClaimed(address,uint256,address,uint256)',
-  },
-  TaskCanceled: {
-    signature: 'TaskCanceled(uint256)',
-  },
-  ExpenditureAdded: {
-    signature: 'ExpenditureAdded(address,uint256)',
-  },
-  ExpenditureTransferred: {
-    signature: 'ExpenditureTransferred(address,uint256,address)',
-  },
-  ExpenditureCancelled: {
-    signature: 'ExpenditureCancelled(address,uint256)',
-  },
-  ExpenditureFinalized: {
-    signature: 'ExpenditureFinalized(address,uint256)',
-  },
-  ExpenditureRecipientSet: {
-    signature: 'ExpenditureRecipientSet(address,uint256,uint256,address)',
-  },
-  ExpenditureSkillSet: {
-    signature: 'ExpenditureSkillSet(address,uint256,uint256,uint256)',
-  },
-  ExpenditurePayoutSet: {
-    signature: 'ExpenditurePayoutSet(address,uint256,uint256,address,uint256)',
-  },
-  Annotation: {
-    signature: 'Annotation(address,bytes32,string)',
-  },
-  PaymentFinalized: {
-    signature: 'PaymentFinalized(address,uint256)',
-  },
-  PaymentPayoutSet: {
-    signature: 'PaymentPayoutSet(address,uint256,address,uint256)',
-  },
-  PaymentRecipientSet: {
-    signature: 'PaymentRecipientSet(address,uint256,address)',
-  },
-  PaymentSkillSet: {
-    signature: 'PaymentSkillSet(address,uint256,uint256)',
-  },
-  ColonyFundingRoleSet: {
-    signature: 'ColonyFundingRoleSet(address,bool)',
-  },
-  ColonyAdministrationRoleSet: {
-    signature: 'ColonyAdministrationRoleSet(address,bool)',
-  },
-  ColonyArchitectureRoleSet: {
-    signature: 'ColonyArchitectureRoleSet(address,bool)',
-  },
-  ColonyRootRoleSet: {
-    signature: 'ColonyRootRoleSet(address,bool)',
-  },
-  // Less common Colony events
-  ColonyBootstrapped: {
-    signature: 'ColonyBootstrapped(address,address[],int256[])',
-  },
-  ColonyUpgraded: {
-    signature: 'ColonyUpgraded(address,uint256,uint256)',
-  },
-  ColonyRoleSet: {
-    signature: 'ColonyRoleSet(address,address,uint256,uint8,bool)',
-  },
-  ColonyRewardInverseSet: {
-    signature: 'ColonyRewardInverseSet(address,uint256)',
-  },
-  FundingPotAdded: {
-    signature: 'FundingPotAdded(uint256)',
-  },
-  RecoveryRoleSet: {
-    signature: 'RecoveryRoleSet(address,bool)',
-  },
-  ColonyMetadata: {
-    signature: 'ColonyMetadata(address,string)',
-  },
-  RecoveryModeEntered: {
-    signature: 'RecoveryModeEntered(address)',
-  },
-  RecoveryModeExitApproved: {
-    signature: 'RecoveryModeExitApproved(address)',
-  },
-  RecoveryModeExited: {
-    signature: 'RecoveryModeExited(address)',
-  },
-  RecoveryStorageSlotSet: {
-    signature: 'RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)',
-  },
-  TaskChangedViaSignatures: {
-    signature: 'TaskChangedViaSignatures(address[])',
-  },
-  TokenUnlocked: {
-    signature: 'TokenUnlocked(address)',
-  },
-  TokensBurned: {
-    signature: 'TokensBurned(address,address,uint256)',
-  },
-  TokensMinted: {
-    signature: 'TokensMinted(address,address,uint256)',
-  },
-  ArbitraryReputationUpdate: {
-    signature: 'ArbitraryReputationUpdate(address,address,uint256,int256)',
-  },
-  ExpenditureClaimDelaySet: {
-    signature: 'ExpenditureClaimDelaySet(address,uint256,uint256,uint256)',
-  },
-  ExpenditureGlobalClaimDelaySet: {
-    signature: 'ExpenditureGlobalClaimDelaySet(address,uint256)',
-  },
-  ExpenditureLocked: {
-    signature: 'ExpenditureLocked(address,uint256)',
-  },
-  ExpenditureMetadataSet: {
-    signature: 'ExpenditureMetadataSet(address,uint256,string)',
-  },
-  ExpenditurePayoutModifierSet: {
-    signature: 'ExpenditurePayoutModifierSet(address,uint256,uint256,int256)',
-  },
-  ColonyMetadataDelta: {
-    signature: 'ColonyMetadataDelta(address,string)',
-  },
-  DomainDeprecated: {
-    signature: 'DomainDeprecated(address,uint256,bool)',
-  },
-  LocalSkillAdded: {
-    signature: 'LocalSkillAdded(address,uint256)',
-  },
-  LocalSkillDeprecated: {
-    signature: 'LocalSkillDeprecated(address,uint256,bool)',
-  },
-  MetaTransactionExecuted: {
-    signature: 'MetaTransactionExecuted(address,address,bytes)',
-  },
-});
-/* eslint-enable max-len */
-
-export const OneTxPaymentEvents = createEventMap('OneTxPayment', {
-  OneTxPaymentMade: {
-    signature: 'OneTxPaymentMade(address,uint256,uint256)',
-  },
-});
-
-export const VotingReputationEvents = createEventMap('VotingReputation', {
-  ExtensionInitialised: {
-    signature: 'ExtensionInitialised()',
-  },
-  LogSetAuthority: {
-    signature: 'LogSetAuthority(address)',
-  },
-  LogSetOwner: {
-    signature: 'LogSetOwner(address)',
-  },
-  MotionCreated: {
-    signature: 'MotionCreated(uint256,address,uint256)',
-  },
-  MotionEscalated: {
-    signature: 'MotionEscalated(uint256,address,uint256,uint256)',
-  },
-  MotionEventSet: {
-    signature: 'MotionEventSet(uint256,uint256)',
-  },
-  MotionFinalized: {
-    signature: 'MotionFinalized(uint256,bytes,bool)',
-  },
-  MotionRewardClaimed: {
-    signature: 'MotionRewardClaimed(uint256,address,uint256,uint256)',
-  },
-  MotionStaked: {
-    signature: 'MotionStaked(uint256,address,uint256,uint256)',
-  },
-  MotionVoteRevealed: {
-    signature: 'MotionVoteRevealed(uint256,address,uint256)',
-  },
-  MotionVoteSubmitted: {
-    signature: 'MotionVoteSubmitted(uint256,address)',
-  },
-  MetaTransactionExecuted: {
-    signature: 'MetaTransactionExecuted(address,address,bytes)',
-  },
-});
+// FIXME: event signature needs to be the key. Maybe it will be easier to type then
+export const EVENTS: EventMap = {
+  ColonyNetwork: {
+    // Common network events
+    ColonyNetworkInitialised: {
+      signature: 'ColonyNetworkInitialised(address)',
+    },
+    ColonyAdded: {
+      signature: 'ColonyAdded(uint256,address,address)',
+    },
+    SkillAdded: {
+      signature: 'SkillAdded(uint256,uint256)',
+    },
+    TokenAuthorityDeployed: {
+      signature: 'TokenAuthorityDeployed(address)',
+    },
+    TokenDeployed: {
+      signature: 'TokenDeployed(address)',
+    },
+    // Less common network events
+    TokenLockingAddressSet: {
+      signature: 'TokenLockingAddressSet(address)',
+    },
+    MiningCycleResolverSet: {
+      signature: 'MiningCycleResolverSet(address)',
+    },
+    NetworkFeeInverseSet: {
+      signature: 'NetworkFeeInverseSet(uint256)',
+    },
+    ColonyVersionAdded: {
+      signature: 'ColonyVersionAdded(uint256,address)',
+    },
+    MetaColonyCreated: {
+      signature: 'MetaColonyCreated(address,address,uint256)',
+    },
+    AuctionCreated: {
+      signature: 'AuctionCreated(address,address,uint256)',
+    },
+    ReputationMiningInitialised: {
+      signature: 'ReputationMiningInitialised(address)',
+    },
+    ReputationMiningCycleComplete: {
+      signature: 'ReputationMiningCycleComplete(bytes32,uint256)',
+    },
+    ReputationRootHashSet: {
+      signature: 'ReputationRootHashSet(bytes32,uint256,address[],uint256)',
+    },
+    UserLabelRegistered: {
+      signature: 'UserLabelRegistered(address,bytes32)',
+    },
+    ColonyLabelRegistered: {
+      signature: 'ColonyLabelRegistered(address,bytes32)',
+    },
+    RecoveryRoleSet: {
+      signature: 'RecoveryRoleSet(address,bool)',
+    },
+    ExtensionAddedToNetwork: {
+      signature: 'ExtensionAddedToNetwork(bytes32,uint256)',
+    },
+    ExtensionDeprecated: {
+      signature: 'ExtensionDeprecated(bytes32,address,bool)',
+    },
+    ExtensionInstalled: {
+      signature: 'ExtensionInstalled(bytes32,address,uint256)',
+    },
+    ExtensionUninstalled: {
+      signature: 'ExtensionUninstalled(bytes32,address)',
+    },
+    ExtensionUpgraded: {
+      signature: 'ExtensionUpgraded(bytes32,address,uint256)',
+    },
+    RecoveryModeEntered: {
+      signature: 'RecoveryModeEntered(address)',
+    },
+    RecoveryModeExitApproved: {
+      signature: 'RecoveryModeExitApproved(address)',
+    },
+    RecoveryModeExited: {
+      signature: 'RecoveryModeExited(address)',
+    },
+    RecoveryStorageSlotSet: {
+      signature: 'RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)',
+    },
+    RegistrarInitialised: {
+      signature: 'RegistrarInitialised(address,bytes32)',
+    },
+    ReputationMinerPenalised: {
+      signature: 'ReputationMinerPenalised(address,uint256)',
+    },
+    ReputationMiningRewardSet: {
+      signature: 'ReputationMiningRewardSet(uint256)',
+    },
+    TokenWhitelisted: {
+      signature: 'TokenWhitelisted(address,bool)',
+    },
+    MetaTransactionExecuted: {
+      signature: 'MetaTransactionExecuted(address,address,bytes)',
+    },
+  },
+  Colony: {
+    // Common Colony events
+    DomainAdded: {
+      signature: 'DomainAdded(address,uint256)',
+      connectedEvents: ['DomainMetadata', 'Annotation'],
+    },
+    DomainMetadata: {
+      signature: 'DomainMetadata(address,uint256,string)',
+      auxiliaryEvent: true,
+    },
+    ColonyInitialised: {
+      signature: 'ColonyInitialised(address,address,address)',
+    },
+    ColonyFundsMovedBetweenFundingPots: {
+      signature:
+        // eslint-disable-next-line max-len
+        'ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)',
+    },
+    ColonyFundsClaimed: {
+      signature: 'ColonyFundsClaimed(address,address,uint256,uint256)',
+    },
+    RewardPayoutCycleStarted: {
+      signature: 'RewardPayoutCycleStarted(address,uint256)',
+    },
+    RewardPayoutCycleEnded: {
+      signature: 'RewardPayoutCycleEnded(address,uint256)',
+    },
+    RewardPayoutClaimed: {
+      signature: 'RewardPayoutClaimed(uint256,address,uint256,uint256)',
+    },
+    PaymentAdded: {
+      signature: 'PaymentAdded(address,uint256)',
+    },
+    TaskAdded: {
+      signature: 'TaskAdded(address,uint256)',
+    },
+    TaskBriefSet: {
+      signature: 'TaskBriefSet(uint256,bytes32)',
+    },
+    TaskDueDateSet: {
+      signature: 'TaskDueDateSet(uint256,uint256)',
+    },
+    TaskDomainSet: {
+      signature: 'TaskDomainSet(uint256,uint256)',
+    },
+    TaskSkillSet: {
+      signature: 'TaskSkillSet(uint256,uint256)',
+    },
+    TaskRoleUserSet: {
+      signature: 'TaskRoleUserSet(uint256,uint8,address)',
+    },
+    TaskPayoutSet: {
+      signature: 'TaskPayoutSet(uint256,uint8,address,uint256)',
+    },
+    TaskDeliverableSubmitted: {
+      signature: 'TaskDeliverableSubmitted(address,uint256,bytes32)',
+    },
+    TaskCompleted: {
+      signature: 'TaskCompleted(address,uint256)',
+    },
+    TaskWorkRatingRevealed: {
+      signature: 'TaskWorkRatingRevealed(address,uint256,uint8,uint8)',
+    },
+    TaskFinalized: {
+      signature: 'TaskFinalized(address,uint256)',
+    },
+    PayoutClaimed: {
+      signature: 'PayoutClaimed(address,uint256,address,uint256)',
+    },
+    TaskCanceled: {
+      signature: 'TaskCanceled(uint256)',
+    },
+    ExpenditureAdded: {
+      signature: 'ExpenditureAdded(address,uint256)',
+    },
+    ExpenditureTransferred: {
+      signature: 'ExpenditureTransferred(address,uint256,address)',
+    },
+    ExpenditureCancelled: {
+      signature: 'ExpenditureCancelled(address,uint256)',
+    },
+    ExpenditureFinalized: {
+      signature: 'ExpenditureFinalized(address,uint256)',
+    },
+    ExpenditureRecipientSet: {
+      signature: 'ExpenditureRecipientSet(address,uint256,uint256,address)',
+    },
+    ExpenditureSkillSet: {
+      signature: 'ExpenditureSkillSet(address,uint256,uint256,uint256)',
+    },
+    ExpenditurePayoutSet: {
+      signature:
+        'ExpenditurePayoutSet(address,uint256,uint256,address,uint256)',
+    },
+    Annotation: {
+      signature: 'Annotation(address,bytes32,string)',
+      auxiliaryEvent: true,
+    },
+    PaymentFinalized: {
+      signature: 'PaymentFinalized(address,uint256)',
+    },
+    PaymentPayoutSet: {
+      signature: 'PaymentPayoutSet(address,uint256,address,uint256)',
+    },
+    PaymentRecipientSet: {
+      signature: 'PaymentRecipientSet(address,uint256,address)',
+    },
+    PaymentSkillSet: {
+      signature: 'PaymentSkillSet(address,uint256,uint256)',
+    },
+    ColonyFundingRoleSet: {
+      signature: 'ColonyFundingRoleSet(address,bool)',
+    },
+    ColonyAdministrationRoleSet: {
+      signature: 'ColonyAdministrationRoleSet(address,bool)',
+    },
+    ColonyArchitectureRoleSet: {
+      signature: 'ColonyArchitectureRoleSet(address,bool)',
+    },
+    ColonyRootRoleSet: {
+      signature: 'ColonyRootRoleSet(address,bool)',
+    },
+    // Less common Colony events
+    ColonyBootstrapped: {
+      signature: 'ColonyBootstrapped(address,address[],int256[])',
+    },
+    ColonyUpgraded: {
+      signature: 'ColonyUpgraded(address,uint256,uint256)',
+    },
+    ColonyRoleSet: {
+      signature: 'ColonyRoleSet(address,address,uint256,uint8,bool)',
+    },
+    ColonyRewardInverseSet: {
+      signature: 'ColonyRewardInverseSet(address,uint256)',
+    },
+    FundingPotAdded: {
+      signature: 'FundingPotAdded(uint256)',
+    },
+    RecoveryRoleSet: {
+      signature: 'RecoveryRoleSet(address,bool)',
+    },
+    ColonyMetadata: {
+      signature: 'ColonyMetadata(address,string)',
+    },
+    RecoveryModeEntered: {
+      signature: 'RecoveryModeEntered(address)',
+    },
+    RecoveryModeExitApproved: {
+      signature: 'RecoveryModeExitApproved(address)',
+    },
+    RecoveryModeExited: {
+      signature: 'RecoveryModeExited(address)',
+    },
+    RecoveryStorageSlotSet: {
+      signature: 'RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)',
+    },
+    TaskChangedViaSignatures: {
+      signature: 'TaskChangedViaSignatures(address[])',
+    },
+    TokenUnlocked: {
+      signature: 'TokenUnlocked(address)',
+    },
+    TokensBurned: {
+      signature: 'TokensBurned(address,address,uint256)',
+    },
+    TokensMinted: {
+      signature: 'TokensMinted(address,address,uint256)',
+    },
+    ArbitraryReputationUpdate: {
+      signature: 'ArbitraryReputationUpdate(address,address,uint256,int256)',
+    },
+    ExpenditureClaimDelaySet: {
+      signature: 'ExpenditureClaimDelaySet(address,uint256,uint256,uint256)',
+    },
+    ExpenditureGlobalClaimDelaySet: {
+      signature: 'ExpenditureGlobalClaimDelaySet(address,uint256)',
+    },
+    ExpenditureLocked: {
+      signature: 'ExpenditureLocked(address,uint256)',
+    },
+    ExpenditureMetadataSet: {
+      signature: 'ExpenditureMetadataSet(address,uint256,string)',
+    },
+    ExpenditurePayoutModifierSet: {
+      signature: 'ExpenditurePayoutModifierSet(address,uint256,uint256,int256)',
+    },
+    ColonyMetadataDelta: {
+      signature: 'ColonyMetadataDelta(address,string)',
+    },
+    DomainDeprecated: {
+      signature: 'DomainDeprecated(address,uint256,bool)',
+    },
+    LocalSkillAdded: {
+      signature: 'LocalSkillAdded(address,uint256)',
+    },
+    LocalSkillDeprecated: {
+      signature: 'LocalSkillDeprecated(address,uint256,bool)',
+    },
+    MetaTransactionExecuted: {
+      signature: 'MetaTransactionExecuted(address,address,bytes)',
+    },
+  },
+  OneTxPayment: {
+    'OneTxPaymentMade(address,uint256,uint256)': {
+      signature: 'OneTxPaymentMade(address,uint256,uint256)',
+      // connectedEvents: [''],
+    },
+    OneTxPaymentMade: {
+      signature: 'OneTxPaymentMade',
+    },
+  },
+  VotingReputation: {
+    ExtensionInitialised: {
+      signature: 'ExtensionInitialised()',
+    },
+    LogSetAuthority: {
+      signature: 'LogSetAuthority(address)',
+    },
+    LogSetOwner: {
+      signature: 'LogSetOwner(address)',
+    },
+    MotionCreated: {
+      signature: 'MotionCreated(uint256,address,uint256)',
+    },
+    MotionEscalated: {
+      signature: 'MotionEscalated(uint256,address,uint256,uint256)',
+    },
+    MotionEventSet: {
+      signature: 'MotionEventSet(uint256,uint256)',
+    },
+    MotionFinalized: {
+      signature: 'MotionFinalized(uint256,bytes,bool)',
+    },
+    MotionRewardClaimed: {
+      signature: 'MotionRewardClaimed(uint256,address,uint256,uint256)',
+    },
+    MotionStaked: {
+      signature: 'MotionStaked(uint256,address,uint256,uint256)',
+    },
+    MotionVoteRevealed: {
+      signature: 'MotionVoteRevealed(uint256,address,uint256)',
+    },
+    MotionVoteSubmitted: {
+      signature: 'MotionVoteSubmitted(uint256,address)',
+    },
+    MetaTransactionExecuted: {
+      signature: 'MetaTransactionExecuted(address,address,bytes)',
+    },
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { ColonyEventManager } from '@colony/sdk';
 import { Client, Intents, Message } from 'discord.js';
 import { providers } from 'ethers';
 
-import { ColonyEvents } from './events';
+import { EVENTS } from './events';
 
 const { DISCORD_TOKEN } = process.env;
 
@@ -20,7 +20,12 @@ client.once('ready', async () => {
 
   const eventList = eventManager.createMultiFilter(
     eventManager.eventSources.Colony,
-    [ColonyEvents.DomainAdded.signature, ColonyEvents.DomainMetadata.signature],
+    [
+      // @ts-ignore: We're going to fix this
+      EVENTS.Colony['DomainAdded(address,uint256)'].signature,
+      // @ts-ignore: We're going to fix this
+      EVENTS.Colony['DomainMetadata(address,uint256,string)'].signature,
+    ],
     '0x6899e0775f56e078C4172B86D411a0623ccCaB24',
   );
 
@@ -38,11 +43,16 @@ client.once('ready', async () => {
         if (chan?.isText()) {
           let message: Message<boolean> | undefined;
           const domainAddedEvent = events.find(
-            ({ eventName }) => eventName === ColonyEvents.DomainAdded.signature,
+            ({ eventName }) =>
+              eventName ===
+              // @ts-ignore: We're going to fix this
+              EVENTS.Colony['DomainAdded(address,uint256)'].signature,
           );
           const domainMetadataEvent = events.find(
             ({ eventName }) =>
-              eventName === ColonyEvents.DomainMetadata.signature,
+              eventName ===
+              // @ts-ignore: We're going to fix this
+              EVENTS.Colony['DomainMetadata(address,uint256,string)'].signature,
           );
           if (domainAddedEvent) {
             message = await chan.send(


### PR DESCRIPTION
The event list needs to be in a different format to accommodate the new requirements for async event caching.

The string that is currently in the `signature` prop should be the key of the object.

E.g.
```typescript
    ColonyNetworkInitialised: {
      signature: 'ColonyNetworkInitialised(address)',
    },
```
should become
```typescript
    'ColonyNetworkInitialised(address)': {
      signature: 'ColonyNetworkInitialised(address)',
    },
```

Furthermore all of the event source objects are now gathered in one big `EVENT` object.